### PR TITLE
Add .env file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ npm-debug.log
 
 # Webstorm
 .idea
+
+# Environment Variables
+.env

--- a/README.md
+++ b/README.md
@@ -86,9 +86,16 @@ Examples:
 #### Setting Options Automatically
 If you want to not provide the options such as `--dbConnectionUri` to the program every time you have 2 options.
 
-**1. Set the option as an Environment Variable with the prefix MIGRATE_**
-```
+**1. Set the option as an Environment Variable with the prefix MIGRATE_**  
+Using a Javascript file:
+```javascript
+//index.js
 export MIGRATE_dbConnectionUri=localhost/migrations
+```
+.env files are also supported:
+```bash
+#.env
+MIGRATE_dbConnectionUri=localhost/migrations
 ```
 **2. Provide a config file (defaults to *migrate.json* or *migrate.js*)**
 ```bash

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-register": "^6.18.0",
     "bluebird": "^3.3.3",
     "colors": "^1.1.2",
+    "dotenv": "^5.0.1",
     "inquirer": "^0.12.0",
     "mkdirp": "^0.5.1",
     "mongoose": "^4.4.6",

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,9 +3,11 @@
 import path from 'path';
 import yargs from 'yargs';
 import 'colors';
+import dotenv from 'dotenv';
 
 import Migrator from './lib';
 
+dotenv.config();
 let  { argv: args } = yargs
   .usage("Usage: migrate -d <mongo-uri> [[create|up|down <migration-name>]|list] [optional options]")
   .demand(1)


### PR DESCRIPTION
Adding .env file support. This provides a convenient mechanism for separating generic configuration data that can be committed to source control, from sensitive configuration data that should not (such as database connection strings with embedded credentials). The JSON configuration file can be used for the former, and .env files for the latter.